### PR TITLE
docs: Update qa_chat_history tutorial to use non-deprecated method

### DIFF
--- a/docs/core_docs/docs/tutorials/qa_chat_history.ipynb
+++ b/docs/core_docs/docs/tutorials/qa_chat_history.ipynb
@@ -451,7 +451,7 @@
     "import { BaseMessage, isAIMessage } from \"@langchain/core/messages\";\n",
     "\n",
     "const prettyPrint = (message: BaseMessage) => {\n",
-    "  let txt = `[${message._getType()}]: ${message.content}`;\n",
+    "  let txt = `[${message.getType()}]: ${message.content}`;\n",
     "  if (\n",
     "    (isAIMessage(message) && message.tool_calls?.length) ||\n",
     "    0 > 0\n",


### PR DESCRIPTION
## Description

Updated the `prettyPrint` function in the qa_chat_history tutorial to use the non-deprecated `getType()` method instead of `_getType()`.

## Changes
- Changed `message._getType()` to `message.getType()` in the prettyPrint helper function
- The `_getType()` method signature is deprecated and should be replaced with `getType()`

## Type of Change
- [x] Documentation update